### PR TITLE
Regularise ONESHOT output

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1143,14 +1143,6 @@ void RCOutput::timer_tick(uint32_t time_out_us)
     if (min_pulse_trigger_us == 0) {
         return;
     }
-
-    uint32_t now = AP_HAL::micros();
-
-    if (now > min_pulse_trigger_us &&
-        now - min_pulse_trigger_us > 4000) {
-        // trigger at a minimum of 250Hz
-        trigger_groups();
-    }
 }
 
 // send dshot for all groups that support it


### PR DESCRIPTION
..In order to get one pulse every controller loop. Useful to drive digital servos on planes. 
loop rate at 100Hz -> servo output at 100Hz in sync with the loop.