### PR TITLE
Shorten OSD plus codes

### DIFF
--- a/libraries/AP_OLC/AP_OLC.cpp
+++ b/libraries/AP_OLC/AP_OLC.cpp
@@ -183,9 +183,10 @@ int AP_OLC::encode_grid(uint32_t lat, uint32_t lon, size_t length,
     return pos;
 }
 
-int AP_OLC::olc_encode(int32_t lat, int32_t lon, size_t length, char *buf, size_t bufsize)
+int AP_OLC::olc_encode(int32_t lat, int32_t lon, size_t length, bool shorten, char *buf, size_t bufsize)
 {
     int pos = 0;
+    int digitsRemoved = shorten ? 4 : 0;
 
     length = MIN(length, CODE_LEN_MAX);
 
@@ -198,7 +199,8 @@ int AP_OLC::olc_encode(int32_t lat, int32_t lon, size_t length, char *buf, size_
     if (length > PAIR_CODE_LEN) {
         pos += encode_grid(alat, alon, length - PAIR_CODE_LEN, buf + pos, bufsize - pos);
     }
-    buf[pos] = '\0';
+    memmove(buf, buf + digitsRemoved, pos - digitsRemoved);
+    buf[pos - digitsRemoved] = '\0';
     return pos;
 }
 

--- a/libraries/AP_OLC/AP_OLC.h
+++ b/libraries/AP_OLC/AP_OLC.h
@@ -33,7 +33,7 @@ public:
     // olc_encodes the given coordinates in lat and lon (deg * OLC_DEG_MULTIPLIER)
     // as an OLC code of the given length. It returns the number of characters
     // written to buf.
-    static int olc_encode(int32_t lat, int32_t lon, size_t length, char *buf, size_t bufsize);
+    static int olc_encode(int32_t lat, int32_t lon, size_t length, bool shorten, char *buf, size_t bufsize);
 
 private:
     static const int32_t initial_exponent;

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: OSD Options
     // @Description: This sets options that change the display
-    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll, 3:Convert feet to miles at 5280ft instead of 10000ft, 4:DisableCrosshair
+    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll, 3:Convert feet to miles at 5280ft instead of 10000ft, 4:DisableCrosshair, 23:Shorten Pluscode
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 8, AP_OSD, options, OPTION_DECIMAL_PACK),
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -501,6 +501,7 @@ public:
         OPTION_INVERTED_AH_ROLL = 1U<<2,
         OPTION_IMPERIAL_MILES = 1U<<3,
         OPTION_DISABLE_CROSSHAIR = 1U<<4,
+        OPTION_SHORTEN_PLUSCODE = 1U<<23,
     };
 
     enum {

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2104,9 +2104,9 @@ void AP_OSD_Screen::draw_clk(uint8_t x, uint8_t y)
     uint8_t hour, min, sec;
     uint16_t ms;
     if (!rtc.get_local_time(hour, min, sec, ms)) {
-    backend->write(x, y, false, "%c--:--", SYMBOL(SYM_CLK));
+        backend->write(x, y, false, "%c--:--", SYMBOL(SYM_CLK));
     } else {
-    backend->write(x, y, false, "%c%02u:%02u", SYMBOL(SYM_CLK), hour, min);
+        backend->write(x, y, false, "%c%02u:%02u", SYMBOL(SYM_CLK), hour, min);
     }
 }
 
@@ -2116,10 +2116,10 @@ void AP_OSD_Screen::draw_pluscode(uint8_t x, uint8_t y)
     AP_GPS & gps = AP::gps();
     const Location &loc = gps.location();
     char buff[16];
-    if (gps.status() == AP_GPS::NO_GPS || gps.status() == AP_GPS::NO_FIX){
-        backend->write(x, y, false, "--------+--");
+    if (gps.status() == AP_GPS::NO_GPS || gps.status() == AP_GPS::NO_FIX) {
+        backend->write(x, y, false, check_option(AP_OSD::OPTION_SHORTEN_PLUSCODE) ? "----+---" : "--------+---");
     } else {
-        AP_OLC::olc_encode(loc.lat, loc.lng, 10, buff, sizeof(buff));
+        AP_OLC::olc_encode(loc.lat, loc.lng, 11, check_option(AP_OSD::OPTION_SHORTEN_PLUSCODE), buff, sizeof(buff));
         backend->write(x, y, false, "%s", buff);
     }
 }


### PR DESCRIPTION
This chops of the first four digits from the OSD plus code since you don't need them if you have a reference location within ~40 km. I also added the 11th digit to increase the precision from 13.9 meters to 2.8 x 3.5 meters. Together, this saves three characters on the OSD. To keep things simple I didn't add parameters or defines to configure the formatting. This way should work fine for everyone.