### PR TITLE
Add OSD input throttle element

### DIFF
--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -135,6 +135,7 @@ float Plane::get_throttle_input(bool no_deadzone) const
         // RC option for reverse throttle has been set
         ret = -ret;
     }
+    plane.osd.set_rc_throttle(ret);
     return ret;
 }
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -207,6 +207,7 @@ private:
     AP_OSD_Setting sidebars{false, 4, 5};
     AP_OSD_Setting power{true, 1, 1};
     AP_OSD_Setting energy{false, 0, 0};
+    AP_OSD_Setting rc_throttle{false, 0, 0};
 
     // MSP OSD only
     AP_OSD_Setting crosshair{false, 0, 0};
@@ -235,6 +236,7 @@ private:
     void draw_horizon(uint8_t x, uint8_t y);
     void draw_home(uint8_t x, uint8_t y);
     void draw_throttle(uint8_t x, uint8_t y);
+    void draw_throttle_value(uint8_t x, uint8_t y, float throttle_v);
     void draw_heading(uint8_t x, uint8_t y);
 #ifdef HAL_OSD_SIDEBAR_ENABLE
     void draw_sidebars(uint8_t x, uint8_t y);
@@ -286,6 +288,7 @@ private:
     void draw_hgt_abvterr(uint8_t x, uint8_t y);
     void draw_fence(uint8_t x, uint8_t y);
     void draw_rngf(uint8_t x, uint8_t y);
+    void draw_rc_throttle(uint8_t x, uint8_t y);
 
 
     struct {
@@ -566,6 +569,8 @@ public:
         _disable = false;
     }
 
+    void set_rc_throttle(float value) { rc_throttle = value; }
+
     AP_OSD_AbstractScreen& get_screen(uint8_t idx) {
 #if OSD_PARAM_ENABLED
         if (idx >= AP_OSD_NUM_DISPLAY_SCREENS) {
@@ -630,6 +635,9 @@ private:
     float avg_current_a;
     float avg_power_w;
 #endif
+
+    float rc_throttle;
+
     AP_OSD_Backend *backend;
 
     static AP_OSD *_singleton;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1088,6 +1088,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(energy, "ENERGY", 63, AP_OSD_Screen, AP_OSD_Setting),
 
+    // @Param: RC_THROTTLE_EN
+    // @DisplayName: RC_THROTTLE_EN
+    // @Description: Displays input throttle value (plane only)
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: RC_THROTTLE_X
+    // @DisplayName: RC_THROTTLE_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: RC_THROTTLE_Y
+    // @DisplayName: RC_THROTTLE_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(rc_throttle, "RC_THR", 3, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -1683,11 +1699,10 @@ void AP_OSD_Screen::draw_heading(uint8_t x, uint8_t y)
     backend->write(x, y, false, "%3d%c", yaw, SYMBOL(SYM_DEGR));
 }
 
-void AP_OSD_Screen::draw_throttle(uint8_t x, uint8_t y)
+void AP_OSD_Screen::draw_throttle_value(uint8_t x, uint8_t y, float throttle_v)
 {
     const char *format;
     uint8_t spaces;
-    float throttle_v = gcs().get_hud_throttle();
     float throttle_abs = fabsf(throttle_v);
     if (osd->options & AP_OSD::OPTION_ONE_DECIMAL_THROTTLE) {
         if (throttle_abs < 9.95) {
@@ -1716,6 +1731,11 @@ void AP_OSD_Screen::draw_throttle(uint8_t x, uint8_t y)
         spaces -= 1;
     }
     backend->write(x + spaces, y, false, format, throttle_v, SYMBOL(SYM_PCNT));
+}
+
+void AP_OSD_Screen::draw_throttle(uint8_t x, uint8_t y)
+{
+    draw_throttle_value(x, y, gcs().get_hud_throttle());
 }
 
 #if HAL_OSD_SIDEBAR_ENABLE
@@ -2332,6 +2352,10 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
     }
 }
 
+void AP_OSD_Screen::draw_rc_throttle(uint8_t x, uint8_t y) {
+    draw_throttle_value(x, y, osd->rc_throttle);
+}
+
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 #if HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT
@@ -2414,6 +2438,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(eff);
     DRAW_SETTING(callsign);
     DRAW_SETTING(current2);
+    DRAW_SETTING(rc_throttle);
 }
 #endif
 #endif // OSD_ENABLED


### PR DESCRIPTION
Useful for:
- TECS tuning since throttle values without voltage compensation are needed
- Checking the effect of voltage compensation on the throttle