### PR TITLE
Fix motors running at full reverse throttle when arming and THR_MIN>=0 when reverse thrust is configured

### DIFF
--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -117,7 +117,7 @@ case Mode::Number::THERMAL:
  */
 bool Plane::have_reverse_thrust(void) const
 {
-    return aparm.throttle_min < 0;
+    return aparm.throttle_min < 0 || have_reverse_throttle_rc_option;
 }
 
 /*


### PR DESCRIPTION
This is solving the issue where the motor(s) will start running at full reverse throttle if you have reverse throttle configured but you set `THR_MIN` >= 0