### PR TITLE
Add deadband for cruise airspeed control

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -153,7 +153,7 @@ void Plane::calc_airspeed_errors()
         } else if (g2.flight_options & FlightOptions::CRUISE_TRIM_THROTTLE) {
             float control_min = 0.0f;
             float control_mid = 0.0f;
-            const float control_mid_deadband = 0.1f;
+            const float control_mid_deadband = 10.0f;
             const float control_max = channel_throttle->get_range();
             const float control_in = get_throttle_input();
             switch (channel_throttle->get_type()) {

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -153,7 +153,6 @@ void Plane::calc_airspeed_errors()
         } else if (g2.flight_options & FlightOptions::CRUISE_TRIM_THROTTLE) {
             float control_min = 0.0f;
             float control_mid = 0.0f;
-            const float control_mid_deadband = 10.0f;
             const float control_max = channel_throttle->get_range();
             const float control_in = get_throttle_input();
             switch (channel_throttle->get_type()) {
@@ -164,14 +163,17 @@ void Plane::calc_airspeed_errors()
                     control_mid = channel_throttle->get_control_mid();
                     break;
             }
-            if (control_in <= (control_mid - control_mid_deadband)) {
+            const float mid_stick_deadband = 0.1f;
+            const float deadband_neg = mid_stick_deadband * (control_mid - control_min);
+            const float deadband_pos = mid_stick_deadband * (control_max - control_mid);
+            if (control_in <= (control_mid - deadband_neg)) {
                 target_airspeed_cm = linear_interpolate(aparm.airspeed_min * 100, aparm.airspeed_cruise_cm,
                                                         control_in,
-                                                        control_min, control_mid - control_mid_deadband);
-            } else if (control_in >= (control_mid + control_mid_deadband)) {
+                                                        control_min, control_mid - deadband_neg);
+            } else if (control_in >= (control_mid + deadband_pos)) {
                 target_airspeed_cm = linear_interpolate(aparm.airspeed_cruise_cm, aparm.airspeed_max * 100,
                                                         control_in,
-                                                        control_mid + control_mid_deadband, control_max);
+                                                        control_mid + deadband_pos, control_max);
             } else {
                 target_airspeed_cm = aparm.airspeed_cruise_cm;
             }


### PR DESCRIPTION
This adds a hard-coded 10% deadband around the center throttle position to make it easier to target exactly the configured cruise airspeed. This only applies when using the center stick position for cruise airpeed (bit 2 of `FLIGHT_OPTIONS`).

I am still not 100% sure if the throttle range in this part of the code is 0.0-1.0 or 0-100. For now I assumed it is the former but I have not tested this yet.