### PR TITLE
OSD: add vehicle acceleration elements

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -199,6 +199,14 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_W_RESTVOLT", 25, AP_OSD, warn_restvolt, 10.0f),
 
+    // @Param: _W_VERT_ACC
+    // @DisplayName: Underspeed warn speed
+    // @Description: Set speed under which ASPDx items will flash
+    // @Range: 0 1000
+    // @Units: m/s
+    // @User: Standard
+    AP_GROUPINFO("_W_VERT_ACC", 60, AP_OSD, warn_vert_acc, 0),
+
     // @Param: _W_ASPD_LOW
     // @DisplayName: Underspeed warn speed
     // @Description: Set speed under which ASPDx items will flash

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -208,6 +208,9 @@ private:
     AP_OSD_Setting energy{false, 0, 0};
     AP_OSD_Setting rc_throttle{false, 0, 0};
     AP_OSD_Setting aspd_dem{false, 0, 0};
+    AP_OSD_Setting acc_long{false, 0, 0};
+    AP_OSD_Setting acc_lat{false, 0, 0};
+    AP_OSD_Setting acc_vert{false, 0, 0};
 
     // MSP OSD only
     AP_OSD_Setting crosshair{false, 0, 0};
@@ -266,6 +269,10 @@ private:
     void draw_gps_longitude(uint8_t x, uint8_t y);
     void draw_roll_angle(uint8_t x, uint8_t y);
     void draw_pitch_angle(uint8_t x, uint8_t y);
+    void draw_acc(uint8_t x, uint8_t y, float acc, uint8_t neg_symbol, uint8_t zero_symbol, uint8_t pos_symbol, float warn);
+    void draw_acc_long(uint8_t x , uint8_t y);
+    void draw_acc_lat(uint8_t x , uint8_t y);
+    void draw_acc_vert(uint8_t x , uint8_t y);
     void draw_temp(uint8_t x, uint8_t y);
 #if BARO_MAX_INSTANCES > 1
     void draw_btemp(uint8_t x, uint8_t y);
@@ -296,6 +303,10 @@ private:
         bool load_attempted;
         const char *str;
     } callsign_data;
+
+    AverageFilter<float,float,10> _acc_long_filter;
+    AverageFilter<float,float,10> _acc_lat_filter;
+    AverageFilter<float,float,10> _acc_vert_filter;
 };
 #endif // OSD_ENABLED
 
@@ -499,6 +510,7 @@ public:
     AP_Float warn_bat2volt;
     AP_Float warn_aspd_low;
     AP_Float warn_aspd_high;
+    AP_Float warn_vert_acc;
     AP_Int8 msgtime_s;
     AP_Int8 arm_scr;
     AP_Int8 disarm_scr;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1120,6 +1120,54 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(aspd_dem, "ASPD_DEM", 61, AP_OSD_Screen, AP_OSD_Setting),
 
+    // @Param: ACC_LONG_EN
+    // @DisplayName: ACC_LONG_EN
+    // @Description: Displays the aircraft's longitudinal acceleration in g
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: ACC_LONG_X
+    // @DisplayName: ACC_LONG_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: ACC_LONG_Y
+    // @DisplayName: ACC_LONG_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(acc_long, "ACC_LONG", 60, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: ACC_LAT_EN
+    // @DisplayName: ACC_LAT_EN
+    // @Description: Displays the aircraft's lateral acceleration in g
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: ACC_LAT_X
+    // @DisplayName: ACC_LAT_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: ACC_LAT_Y
+    // @DisplayName: ACC_LAT_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(acc_lat, "ACC_LAT", 59, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: ACC_VERT_EN
+    // @DisplayName: ACC_VERT_EN
+    // @Description: Displays the aircraft's vertical acceleration in g
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: ACC_VERT_X
+    // @DisplayName: ACC_VERT_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: ACC_VERT_Y
+    // @DisplayName: ACC_VERT_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(acc_vert, "ACC_VERT", 58, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -2058,13 +2106,60 @@ void AP_OSD_Screen::draw_pitch_angle(uint8_t x, uint8_t y)
     backend->write(x, y, false, "%c%3d%c", p, pitch, SYMBOL(SYM_DEGR));
 }
 
+void AP_OSD_Screen::draw_acc(uint8_t x, uint8_t y, float acc, uint8_t neg_symbol, uint8_t zero_symbol, uint8_t pos_symbol, float warn)
+{
+    const float acc_abs = fabsf(acc);
+    const char *format = acc_abs < 9.95 ? " %1.1f%c" : "%2.1f%c";
+    const uint8_t symbol = SYMBOL(acc_abs < 0.05 ? zero_symbol : (signbit(acc) ? neg_symbol : pos_symbol));
+    backend->write(x, y, warn > 0 && acc_abs > warn, format, acc_abs, symbol);
+}
+
+void AP_OSD_Screen::draw_acc_long(uint8_t x, uint8_t y) {
+    AP_AHRS &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+    const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+    const float acc = _acc_long_filter.apply(rotMat.c.x * GRAVITY_MSS + AP::ins().get_accel().x) / GRAVITY_MSS;
+
+    const char *format;
+    uint8_t spaces;
+    const float acc_abs = fabsf(acc);
+    if (acc_abs < 9.95) {
+        spaces = 2;
+        format = "%1.1f";
+    } else {
+        spaces = 1;
+        format = "%2.1f";
+    }
+
+    if (signbit(acc)) {
+        spaces -= 1;
+    }
+
+    backend->write(x + spaces, y, false, format, acc);
+}
+
+void AP_OSD_Screen::draw_acc_lat(uint8_t x, uint8_t y) {
+    AP_AHRS &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+    const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+    const float acc = _acc_lat_filter.apply(rotMat.c.y * GRAVITY_MSS + AP::ins().get_accel().y) / GRAVITY_MSS;
+    draw_acc(x, y, acc, SYM_ROLLR, SYM_ROLL0, SYM_ROLLL, 0);
+}
+
+void AP_OSD_Screen::draw_acc_vert(uint8_t x, uint8_t y) {
+    AP_AHRS &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+    const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+    const float acc = _acc_vert_filter.apply(rotMat.c.z * GRAVITY_MSS + AP::ins().get_accel().z) / GRAVITY_MSS;
+    draw_acc(x, y, acc, SYM_PTCHDWN, SYM_PTCH0, SYM_PTCHUP, osd->warn_vert_acc);
+}
+
 void AP_OSD_Screen::draw_temp(uint8_t x, uint8_t y)
 {
     AP_Baro &barometer = AP::baro();
     float tmp = barometer.get_temperature();
     backend->write(x, y, false, "%3d%c", (int)u_scale(TEMPERATURE, tmp), u_icon(TEMPERATURE));
 }
-
 
 void AP_OSD_Screen::draw_hdop(uint8_t x, uint8_t y)
 {
@@ -2437,6 +2532,9 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(fence);
     DRAW_SETTING(roll_angle);
     DRAW_SETTING(pitch_angle);
+    DRAW_SETTING(acc_long);
+    DRAW_SETTING(acc_lat);
+    DRAW_SETTING(acc_vert);
     DRAW_SETTING(temp);
 #if BARO_MAX_INSTANCES > 1
     DRAW_SETTING(btemp);


### PR DESCRIPTION
Note that these won't work right if your board trim is not 0 or more exactly if what your board's accelerometer measures when the AHRS says it is level is not the gravitational acceleration