### PR TITLE
OSD: display rangefinder altitude only when data is available and sensor in range

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2675,7 +2675,7 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
     if (rangefinder == nullptr) {
        return;
     }
-    if (rangefinder->status_orient(ROTATION_PITCH_270) <= RangeFinder::Status::NoData) {
+    if (rangefinder->status_orient(ROTATION_PITCH_270) < RangeFinder::Status::Good) {
         backend->write(x, y, false, "----%c%c", u_icon(ALTITUDE), SYMBOL(SYM_RNGFD));
     } else {
         AP_AHRS &ahrs = AP::ahrs();


### PR DESCRIPTION
Closes #85 