### PR TITLE
Battery monitoring improvements

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -114,6 +114,7 @@ known_units = {
              'RPM'     : 'Revolutions Per Minute',
              'kRPM'     : 'Thousands of revolutions Per Minute',
              'kg/m/m'  : 'kilograms per square meter', # metre is the SI unit name, meter is the american spelling of it
+             'Wh'      : 'Watt hour'
              }
 
 required_param_fields = [

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -512,6 +512,52 @@ int32_t AP_BattMonitor::pack_capacity_mah(uint8_t instance) const
     }
 }
 
+float AP_BattMonitor::low_capacity_mah(uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES) {
+        return _params[instance]._low_capacity;
+    } else {
+        return 0;
+    }
+}
+
+float AP_BattMonitor::critical_capacity_mah(uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES) {
+        return _params[instance]._critical_capacity;
+    } else {
+        return 0;
+    }
+}
+
+/// pack_capacity_wh - returns the capacity of the battery pack in Wh when the pack is full
+float AP_BattMonitor::pack_capacity_wh(uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES) {
+        return _params[instance]._pack_capacity_wh;
+    } else {
+        return 0;
+    }
+}
+
+float AP_BattMonitor::low_capacity_wh(uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES) {
+        return _params[instance]._low_capacity_wh;
+    } else {
+        return 0;
+    }
+}
+
+float AP_BattMonitor::critical_capacity_wh(uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES) {
+        return _params[instance]._critical_capacity_wh;
+    } else {
+        return 0;
+    }
+}
+
 void AP_BattMonitor::check_failsafes(void)
 {
     if (hal.util->get_soft_armed()) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -199,6 +199,20 @@ public:
     /// pack_capacity_mah - returns the capacity of the battery pack in mAh when the pack is full
     int32_t pack_capacity_mah(uint8_t instance) const;
     int32_t pack_capacity_mah() const { return pack_capacity_mah(AP_BATT_PRIMARY_INSTANCE); }
+
+    float low_capacity_mah(uint8_t instance) const;
+    float low_capacity_mah() const { return low_capacity_mah(AP_BATT_PRIMARY_INSTANCE); }
+    float critical_capacity_mah(uint8_t instance) const;
+    float critical_capacity_mah() const { return critical_capacity_mah(AP_BATT_PRIMARY_INSTANCE); }
+ 
+    /// pack_capacity_wh - returns the capacity of the battery pack in Wh when the pack is full
+    float pack_capacity_wh(uint8_t instance) const;
+    float pack_capacity_wh() const { return pack_capacity_wh(AP_BATT_PRIMARY_INSTANCE); }
+
+    float low_capacity_wh(uint8_t instance) const;
+    float low_capacity_wh() const { return low_capacity_wh(AP_BATT_PRIMARY_INSTANCE); }
+    float critical_capacity_wh(uint8_t instance) const;
+    float critical_capacity_wh() const { return critical_capacity_wh(AP_BATT_PRIMARY_INSTANCE); }
  
     /// returns true if a battery failsafe has ever been triggered
     bool has_failsafed(void) const { return _has_triggered_failsafe; };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -35,8 +35,19 @@ AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonit
 // return false if the battery is unhealthy, does not have current monitoring, or the pack_capacity is too small
 bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const
 {
+    float pack_capacity;
+    float pack_consumed;
+
+    if (_params._options & uint32_t(AP_BattMonitor_Params::Options::Use_Wh_for_remaining_percent_calc)) {
+        pack_capacity = _params._pack_capacity_wh;
+        pack_consumed = _state.consumed_wh;
+    } else {
+        pack_capacity = _params._pack_capacity;
+        pack_consumed = _state.consumed_mah;
+    }
+
     // we consider anything under 10 mAh as being an invalid capacity and so will be our measurement of remaining capacity
-    if ( _params._pack_capacity <= 10) {
+    if (!is_positive(pack_capacity)) {
         return false;
     }
 
@@ -45,8 +56,8 @@ bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const
         return false;
     }
 
-    const float mah_remaining = _params._pack_capacity - _state.consumed_mah;
-    percentage = constrain_float(100 * mah_remaining / _params._pack_capacity, 0, UINT8_MAX);
+    const float remaining = pack_capacity - pack_consumed;
+    percentage = constrain_float(100 * remaining / pack_capacity, 0, UINT8_MAX);
     return true;
 }
 
@@ -168,11 +179,16 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
 
     bool below_arming_voltage = is_positive(_params._arming_minimum_voltage) &&
                                 (_state.voltage < _params._arming_minimum_voltage);
-    bool below_arming_capacity = (_params._arming_minimum_capacity > 0) &&
-                                 ((_params._pack_capacity - _state.consumed_mah) < _params._arming_minimum_capacity);
-    bool fs_capacity_inversion = is_positive(_params._critical_capacity) &&
+    bool below_arming_capacity = ((_params._arming_minimum_capacity > 0) &&
+                                 ((_params._pack_capacity - _state.consumed_mah) < _params._arming_minimum_capacity)) ||
+                                 ((_params._arming_minimum_capacity_wh > 0) &&
+                                 ((_params._pack_capacity_wh - _state.consumed_wh) < _params._arming_minimum_capacity_wh));
+    bool fs_capacity_inversion = (is_positive(_params._critical_capacity) &&
                                  is_positive(_params._low_capacity) &&
-                                 (_params._low_capacity < _params._critical_capacity);
+                                 (_params._low_capacity < _params._critical_capacity)) ||
+                                 (is_positive(_params._critical_capacity_wh) &&
+                                 is_positive(_params._low_capacity_wh) &&
+                                 (_params._low_capacity_wh < _params._critical_capacity_wh));
     bool fs_voltage_inversion = is_positive(_params._critical_voltage) &&
                                 is_positive(_params._low_voltage) &&
                                 (_params._low_voltage < _params._critical_voltage);
@@ -211,8 +227,10 @@ void AP_BattMonitor_Backend::check_failsafe_types(bool &low_voltage, bool &low_c
     }
 
     // check capacity failsafe if current monitoring is enabled
-    if (has_current() && (_params._critical_capacity > 0) &&
-        ((_params._pack_capacity - _state.consumed_mah) < _params._critical_capacity)) {
+    if (has_current() && (((_params._critical_capacity > 0) &&
+        ((_params._pack_capacity - _state.consumed_mah) < _params._critical_capacity)) ||
+        ((_params._critical_capacity_wh > 0) &&
+        ((_params._pack_capacity_wh - _state.consumed_wh) < _params._critical_capacity_wh)))) {
         critical_capacity = true;
     } else {
         critical_capacity = false;
@@ -225,8 +243,10 @@ void AP_BattMonitor_Backend::check_failsafe_types(bool &low_voltage, bool &low_c
     }
 
     // check capacity if current monitoring is enabled
-    if (has_current() && (_params._low_capacity > 0) &&
-        ((_params._pack_capacity - _state.consumed_mah) < _params._low_capacity)) {
+    if (has_current() && (((_params._low_capacity > 0) &&
+        ((_params._pack_capacity - _state.consumed_mah) < _params._low_capacity)) ||
+        ((_params._low_capacity_wh > 0) &&
+        ((_params._pack_capacity_wh - _state.consumed_wh) < _params._low_capacity_wh)))) {
         low_capacity = true;
     } else {
         low_capacity = false;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -145,7 +145,39 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Description: This sets options to change the behaviour of the battery monitor
     // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot
     // @User: Advanced
-    AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
+    AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, float(Options::Use_Wh_for_remaining_percent_calc)),
+
+    // @Param: CAPA_WH
+    // @DisplayName: Battery capacity in Wh
+    // @Description: Capacity of the battery in Wh when full
+    // @Units: Wh
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("CAPA_WH", 58, AP_BattMonitor_Params, _pack_capacity_wh, 0),
+
+    // @Param: LOW_WH
+    // @DisplayName: Low battery capacity
+    // @Description: Battery capacity at which the low battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the @PREFIX@FS_LOW_ACT parameter.
+    // @Units: Wh
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("LOW_WH", 59, AP_BattMonitor_Params, _low_capacity_wh, 0),
+
+    // @Param: CRT_WH
+    // @DisplayName: Battery critical capacity
+    // @Description: Battery capacity at which the critical battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the @PREFIX@_FS_CRT_ACT parameter.
+    // @Units: Wh
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("CRT_WH", 60, AP_BattMonitor_Params, _critical_capacity_wh, 0),
+
+    // @Param: ARM_WH
+    // @DisplayName: Required arming remaining capacity
+    // @Description: Battery capacity remaining which is required to arm the aircraft. Set to 0 to allow arming at any capacity. Note that execept for smart batteries rebooting the vehicle will always reset the remaining capacity estimate, which can lead to this check not providing sufficent protection, it is recommended to always use this in conjunction with the @PREFIX@_ARM_VOLT parameter.
+    // @Units: Wh
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("ARM_WH", 61, AP_BattMonitor_Params, _arming_minimum_capacity_wh, 0),
 
     // @Param: CELL_DT_V
     // @DisplayName: Battery cell max voltage

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -17,24 +17,29 @@ public:
         BattMonitor_LowVoltageSource_Raw            = 0,
         BattMonitor_LowVoltageSource_SagCompensated = 1
     };
-    enum class Options : uint8_t {
+    enum class Options : uint32_t {
         Ignore_UAVCAN_SoC                   = (1U<<0),  // Ignore UAVCAN State-of-Charge (charge %) supplied value from the device and use the internally calculated one
         MPPT_Use_Input_Value                = (1U<<1),  // MPPT reports voltage and current from Input (usually solar panel) instead of the output
         MPPT_Power_Off_At_Disarm            = (1U<<2),  // MPPT Disabled when vehicle is disarmed, if HW supports it
         MPPT_Power_On_At_Arm                = (1U<<3),  // MPPT Enabled when vehicle is armed, if HW supports it
         MPPT_Power_Off_At_Boot              = (1U<<4),  // MPPT Disabled at startup (aka boot), if HW supports it
         MPPT_Power_On_At_Boot               = (1U<<5),  // MPPT Enabled at startup (aka boot), if HW supports it. If Power_Off_at_Boot is also set, the behavior is Power_Off_at_Boot
+        Use_Wh_for_remaining_percent_calc   = (1U<<23),
     };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
 
     AP_Int32 _pack_capacity;            /// battery pack capacity less reserve in mAh
+    AP_Float _pack_capacity_wh;         /// battery pack capacity in Wh
     AP_Int32 _serial_number;            /// battery serial number, automatically filled in on SMBus batteries
     AP_Float _low_voltage;              /// voltage level used to trigger a low battery failsafe
     AP_Float _low_capacity;             /// capacity level used to trigger a low battery failsafe
+    AP_Float _low_capacity_wh;          /// capacity level used to trigger a low battery failsafe
     AP_Float _critical_voltage;         /// voltage level used to trigger a critical battery failsafe
     AP_Float _critical_capacity;        /// capacity level used to trigger a critical battery failsafe
+    AP_Float _critical_capacity_wh;        /// capacity level used to trigger a critical battery failsafe
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
+    AP_Float _arming_minimum_capacity_wh;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
     AP_Int32 _options;                  /// Options
     AP_Int16 _watt_max;                 /// max battery power allowed. Reduce max throttle to reduce current to satisfy t    his limit

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1647,10 +1647,13 @@ void AP_OSD_Screen::draw_energy(uint8_t x, uint8_t y)
     AP_BattMonitor &battery = AP::battery();
     float energy_wh;
     if (!battery.consumed_wh(energy_wh)) {
-        energy_wh = 0;
+        // consumed energy unavailable
+        backend->write(x, y, false, "----%c", SYMBOL(SYM_WH));
+        return;
     }
     const char* const fmt = (energy_wh < 9.9995 ? "%1.3f%c" : (energy_wh < 99.995 ? "%2.2f%c" : "%3.1f%c"));
-    backend->write(x, y, false, fmt, energy_wh, SYMBOL(SYM_WH));
+    const bool blink = is_positive(battery.low_capacity_wh()) && (battery.pack_capacity_wh() - energy_wh) < battery.low_capacity_wh();
+    backend->write(x, y, blink, fmt, energy_wh, SYMBOL(SYM_WH));
 }
 
 void AP_OSD_Screen::draw_fltmode(uint8_t x, uint8_t y)
@@ -1679,14 +1682,16 @@ void AP_OSD_Screen::draw_sats(uint8_t x, uint8_t y)
 void AP_OSD_Screen::draw_batused(uint8_t instance, uint8_t x, uint8_t y)
 {
     float mah;
-    if (!AP::battery().consumed_mah(mah, instance)) {
+    AP_BattMonitor &battery = AP::battery();
+    if (!battery.consumed_mah(mah, instance)) {
         mah = 0;
     }
+    const bool blink = is_positive(battery.low_capacity_mah()) && (battery.pack_capacity_mah() - mah) < battery.low_capacity_mah();
     if (mah <= 9999) {
-        backend->write(x,y, false, "%4d%c", (int)mah, SYMBOL(SYM_MAH));
+        backend->write(x,y, blink, "%4d%c", (int)mah, SYMBOL(SYM_MAH));
     } else {
         const float ah = mah * 1e-3f;
-        backend->write(x,y, false, "%2.2f%c", (double)ah, SYMBOL(SYM_AH));
+        backend->write(x,y, blink, "%2.2f%c", (double)ah, SYMBOL(SYM_AH));
     }
 }
 


### PR DESCRIPTION
- Adds params for low and critical Wh capacity
- Adds param for minimum remaining energy for arming
- Adds failsafe on low or critical Wh capacity
- Blink OSD Ah and Wh counters when remaining capacity is lower than the specified low capacity
- Display message when low and critical Wh capacity are reached
- Add option bit in BATT_OPTIONS to use Wh capacity instead of mAh capacity for percentage calculations