### PR TITLE
OSD: offset batt voltage x by 1 if bar not shown

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1584,7 +1584,7 @@ void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
     uint8_t pct;
     if (!battery.capacity_remaining_pct(pct)) {
         // Do not show battery percentage
-        backend->write(x,y, v < osd->warn_batvolt, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
+        backend->write(x+1,y, v < osd->warn_batvolt, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
         return;
     }
     uint8_t p = (100 - pct) / 16.6;


### PR DESCRIPTION
Offset batt voltage x by 1 if bar not shown so that there is no offset between when the bar is shown (battery % available) and when the bar is not shown (battery % not available)