### PR TITLE
Plane: add throttle curves

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -338,6 +338,14 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Advanced
     GSCALAR(throttle_dz,            "THR_DZ",   4),
 
+    // @Param: THR_EXPO
+    // @DisplayName: Manual throttle square response curve
+    // @Description: Amount of square response curve to apply to throttle in manual throttle modes
+    // @Units: %
+    // @Range: 0 100
+    // @User: Advanced
+    GSCALAR(throttle_expo,           "THR_EXPO",   0),
+
     // @Param: TKOFF_THR_MAX
     // @DisplayName: Maximum Throttle for takeoff
     // @Description: The maximum throttle setting during automatic takeoff. If this is zero then THR_MAX is used for takeoff as well.
@@ -1363,9 +1371,6 @@ static const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_land_then_servos_neutral,0, AP_PARAM_INT8,  "LAND_THEN_NEUTRAL" },
     { Parameters::k_param_land_abort_throttle_enable,0,AP_PARAM_INT8, "LAND_ABORT_THR" },
     { Parameters::k_param_land_flap_percent,  0,      AP_PARAM_INT8,  "LAND_FLAP_PERCENT" },
-
-    // battery failsafes
-    { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT, "BATT_LOW_MAH" },
 
     { Parameters::k_param_arming,             3,      AP_PARAM_INT8,  "ARMING_RUDDER" },
     { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -267,7 +267,7 @@ public:
         k_param_throttle_passthru_stabilize,
         k_param_rc_12_old,
         k_param_throttle_dz,
-        k_param_fs_batt_mah,     // unused - moved to AP_BattMonitor
+        k_param_throttle_expo,     // unused - moved to AP_BattMonitor
         k_param_fs_timeout_short,
         k_param_fs_timeout_long,
         k_param_rc_13_old,
@@ -466,6 +466,7 @@ public:
     AP_Int16 gcs_pid_mask;
 
     AP_Float throttle_dz;
+    AP_Int8 throttle_expo;
 };
 
 /*

--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -126,16 +126,24 @@ bool Plane::have_reverse_thrust(void) const
 float Plane::get_throttle_input(bool no_deadzone) const
 {
     float ret;
+
     if (no_deadzone) {
         ret = channel_throttle->get_control_in_zero_dz();
     } else {
         ret = channel_throttle->get_control_in();
     }
+
     if (reversed_throttle) {
         // RC option for reverse throttle has been set
         ret = -ret;
     }
+
     plane.osd.set_rc_throttle(ret);
+
+    if (!control_mode->does_auto_throttle()) {
+        ret = AP_TECS::apply_throttle_expo(ret, g.throttle_expo);
+    }
+
     return ret;
 }
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -54,9 +54,9 @@ public:
 
     // demanded throttle in percentage
     // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
-    float get_throttle_demand(void) {
-        return _throttle_dem * 100.0f;
-    }
+    float get_throttle_demand(void) const;
+
+    static float apply_throttle_expo(float throttle, float expo);
 
     void set_throttle_demand(float throttle_demand) {
         _last_throttle_dem = _throttle_dem = throttle_demand * 0.01f;
@@ -205,6 +205,7 @@ private:
     AP_Float _vel_rate_max;
     AP_Float _thr_ff_damp;
     AP_Float _thr_ff_filter;
+    AP_Int8 _thr_expo;
 
     enum {
         OPTION_GLIDER_ONLY=(1<<0),


### PR DESCRIPTION
Adds THR_EXPO setting adding a configurable square curve to the throttle. Should be set to either 0 or 100 (or close to)
- 0% (default) gives linear propulsion power control
- 100% square curve gives linear airspeed control