### PR TITLE
Even more battery monitoring improvements

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -508,6 +508,36 @@ bool AP_BattMonitor::consumed_wh(float &wh, const uint8_t instance) const {
     }
 }
 
+/// remaining_mah - returns energy remaining in milliampere.hours
+bool AP_BattMonitor::remaining_mah(float &mah, const uint8_t instance) const {
+    if (instance < _num_instances && drivers[instance] != nullptr && drivers[instance]->has_current() && _params[instance]._pack_capacity > 0) {
+        mah = _params[instance]._pack_capacity - state[instance].consumed_mah;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/// remaining_wh - returns energy remaining in watt.hours
+bool AP_BattMonitor::remaining_wh(float &wh, const uint8_t instance) const {
+    if (instance < _num_instances && drivers[instance] != nullptr && drivers[instance]->has_consumed_energy() && is_positive(_params[instance]._pack_capacity_wh)) {
+        wh = _params[instance]._pack_capacity_wh - state[instance].consumed_wh;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/// consumed_wh_without_losses - returns total energy drawn not including battery losses since start-up in watt.hours
+bool AP_BattMonitor::consumed_wh_without_losses(float &wh, const uint8_t instance) const {
+    if (instance < _num_instances && drivers[instance] != nullptr && drivers[instance]->has_consumed_energy()) {
+        wh = state[instance].consumed_wh_without_losses;
+        return true;
+    } else {
+        return false;
+    }
+}
+
 /// capacity_remaining_pct - returns true if the percentage is valid and writes to percentage argument
 bool AP_BattMonitor::capacity_remaining_pct(uint8_t &percentage, uint8_t instance) const
 {
@@ -627,6 +657,40 @@ bool AP_BattMonitor::resting_voltage_is_low(uint8_t instance) const
     }
 }
 
+/// remaining_mah_is_low - returns true if the remaining mah capacity is bellow the configured value
+bool AP_BattMonitor::remaining_mah_is_low(const uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES && is_positive(_params[instance]._low_capacity)) {
+        float remaining;
+        const bool remaining_is_available = remaining_mah(remaining, instance);
+
+        if (!remaining_is_available) {
+            return false;
+        }
+
+        return remaining < _params[instance]._low_capacity;
+    } else {
+        return false;
+    }
+}
+
+/// remaining_wh_is_low - returns true if the remaining Wh capacity is bellow the configured value
+bool AP_BattMonitor::remaining_wh_is_low(const uint8_t instance) const
+{
+    if (instance < AP_BATT_MONITOR_MAX_INSTANCES && is_positive(_params[instance]._low_capacity_wh)) {
+        float remaining;
+        const bool remaining_is_available = remaining_wh(remaining, instance);
+
+        if (!remaining_is_available) {
+            return false;
+        }
+
+        return remaining < _params[instance]._low_capacity_wh;
+    } else {
+        return false;
+    }
+}
+
 void AP_BattMonitor::check_failsafes(void)
 {
     if (hal.util->get_soft_armed()) {
@@ -698,7 +762,30 @@ float AP_BattMonitor::power_watts() const
     return total;
 }
 
+// returns the total power draw for all batteries
+float AP_BattMonitor::power_watts_without_losses() const
+{
+    float total = 0;
+    for (uint8_t instance = 0; instance < _num_instances; instance++) {
+        float instance_power;
+        if (power_watts_without_losses(instance_power, instance)) {
+            total += instance_power;
+        }
+    }
+    return total;
+}
+
 bool AP_BattMonitor::power_watts(float &power, uint8_t instance) const
+{
+    if ((instance < _num_instances) && (drivers[instance] != nullptr) && drivers[instance]->has_current()) {
+        power = state[instance].current_amps * state[instance].voltage_resting_estimate;
+        return true;
+    }
+
+    return false;
+}
+
+bool AP_BattMonitor::power_watts_without_losses(float &power, uint8_t instance) const
 {
     if ((instance < _num_instances) && (drivers[instance] != nullptr) && drivers[instance]->has_current()) {
         power = state[instance].current_amps * state[instance].voltage;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -129,6 +129,7 @@ public:
         float       current_amps;              // current in amperes
         float       consumed_mah;              // total current draw in milliamp hours since start-up
         float       consumed_wh;               // total energy consumed in Wh since start-up
+        float       consumed_wh_without_losses;// total energy consumed in Wh not including battery losses
         uint32_t    last_time_micros;          // time when voltage and current was last read in microseconds
         uint32_t    low_voltage_start_ms;      // time when voltage dropped below the minimum in milliseconds
         uint32_t    critical_voltage_start_ms; // critical voltage failsafe start timer in milliseconds
@@ -192,11 +193,24 @@ public:
     float power_watts() const;
     bool power_watts(float &power, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const;
 
+    /// power watt
+    float power_watts_without_losses() const;
+    bool power_watts_without_losses(float &power, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const;
+
     /// consumed_mah - returns total current drawn since start-up in milliampere.hours
     bool consumed_mah(float &mah, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
 
     /// consumed_wh - returns total energy drawn since start-up in watt.hours
     bool consumed_wh(float&wh, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
+
+    /// remaining_mah - returns energy remaining in milliampere.hours
+    bool remaining_mah(float&mah, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
+
+    /// remaining_wh - returns energy remaining in watt.hours
+    bool remaining_wh(float&wh, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
+
+    /// consumed_wh_without_losses - returns total energy drawn not including battery losses since start-up in watt.hours
+    bool consumed_wh_without_losses(float&wh, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
 
     /// capacity_remaining_pct - returns true if the percentage is valid and writes to percentage argument
     virtual bool capacity_remaining_pct(uint8_t &percentage, uint8_t instance) const WARN_IF_UNUSED;
@@ -236,6 +250,12 @@ public:
  
     bool resting_voltage_is_low(uint8_t instance) const;
     bool resting_voltage_is_low() const { return voltage_is_low(AP_BATT_PRIMARY_INSTANCE); }
+
+    /// remaining_mah_is_low - returns true if the remaining mAh capacity is bellow the configured value
+    bool remaining_mah_is_low(const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const;
+
+    /// remaining_wh_is_low - returns true if the remaining Wh capacity is bellow the configured value
+    bool remaining_wh_is_low(const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const;
 
     /// returns true if a battery failsafe has ever been triggered
     bool has_failsafed(void) const { return _has_triggered_failsafe; };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -104,8 +104,9 @@ AP_BattMonitor_Analog::read()
         if (_state.last_time_micros != 0 && dt < 2000000.0f) {
             float mah = calculate_mah(_state.current_amps, dt);
             _state.consumed_mah += mah;
-            const uint32_t options = uint32_t(_params._options.get());
-            _state.consumed_wh  += 0.001f * mah * (options & uint32_t(AP_BattMonitor_Params::Options::ANA_INCLUDE_UPSTREAM_ENERGY_LOSSES) ? _state.voltage_resting_estimate : _state.voltage);
+            const float ah = mah * 0.001f;
+            _state.consumed_wh  += ah * _state.voltage_resting_estimate;
+            _state.consumed_wh_without_losses += ah * _state.voltage;
         }
 
         // record time

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -145,7 +145,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Description: This sets options to change the behaviour of the battery monitor
     // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 22:Use Wh for remaining battery percentage calculation, 23:Include energy losses upstream of the flight controller when using analog battery monitor
     // @User: Advanced
-    AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, float(int32_t(Options::Use_Wh_for_remaining_percent_calc) | int32_t(Options::ANA_INCLUDE_UPSTREAM_ENERGY_LOSSES))),
+    AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, float(int32_t(Options::Use_Wh_for_remaining_percent_calc))),
 
     // @Param: LOW_CV
     // @DisplayName: Minimum battery cell voltage to consider the battery full

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -24,7 +24,6 @@ public:
         MPPT_Power_On_At_Arm                = (1U<<3),  // MPPT Enabled when vehicle is armed, if HW supports it
         MPPT_Power_Off_At_Boot              = (1U<<4),  // MPPT Disabled at startup (aka boot), if HW supports it
         MPPT_Power_On_At_Boot               = (1U<<5),  // MPPT Enabled at startup (aka boot), if HW supports it. If Power_Off_at_Boot is also set, the behavior is Power_Off_at_Boot
-        ANA_INCLUDE_UPSTREAM_ENERGY_LOSSES  = (1U<<22), // analog battery monitor includes energy losses upstream from FC
         Use_Wh_for_remaining_percent_calc   = (1U<<23),
     };
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -154,6 +154,7 @@ private:
     AP_OSD_Setting link_quality{false,1,1};
     AP_OSD_Setting current{true, 25, 2};
     AP_OSD_Setting batused{true, 23, 3};
+    AP_OSD_Setting batrem{true, 23, 3};
     AP_OSD_Setting sats{true, 1, 3};
     AP_OSD_Setting fltmode{true, 2, 8};
     AP_OSD_Setting message{true, 2, 6};
@@ -192,9 +193,11 @@ private:
     AP_OSD_Setting flightime{false, 23, 10};
     AP_OSD_Setting climbeff{false,0,0};
     AP_OSD_Setting eff{false, 22, 10};
+    AP_OSD_Setting avg_eff{false, 22, 10};
     AP_OSD_Setting atemp{false, 0, 0};
     AP_OSD_Setting bat2_vlt{false, 0, 0};
     AP_OSD_Setting bat2used{false, 0, 0};
+    AP_OSD_Setting bat2rem{false, 0, 0};
     AP_OSD_Setting current2{false, 0, 0};
     AP_OSD_Setting clk{false, 0, 0};
     AP_OSD_Setting callsign{false, 0, 0};
@@ -207,7 +210,8 @@ private:
 #endif
     AP_OSD_Setting sidebars{false, 4, 5};
     AP_OSD_Setting power{true, 1, 1};
-    AP_OSD_Setting energy{false, 0, 0};
+    AP_OSD_Setting energy_consumed{false, 0, 0};
+    AP_OSD_Setting energy_remaining{false, 0, 0};
     AP_OSD_Setting rc_throttle{false, 0, 0};
     AP_OSD_Setting aspd_dem{false, 0, 0};
     AP_OSD_Setting auto_flaps{false, 0, 0};
@@ -240,9 +244,14 @@ private:
     void draw_current(uint8_t x, uint8_t y);
     void draw_current(uint8_t instance, uint8_t x, uint8_t y);
     void draw_power(uint8_t x, uint8_t y);
-    void draw_energy(uint8_t x, uint8_t y);
+    void draw_energy(uint8_t x, uint8_t y, bool available, bool blink, float energy_wh, bool can_be_negative);
+    void draw_energy_consumed(uint8_t x, uint8_t y);
+    void draw_energy_remaining(uint8_t x, uint8_t y);
+    void draw_batused(uint8_t x, uint8_t y, uint8_t instance);
     void draw_batused(uint8_t x, uint8_t y);
-    void draw_batused(uint8_t instance, uint8_t x, uint8_t y);
+    void draw_batrem(uint8_t x, uint8_t y, uint8_t instance);
+    void draw_batrem(uint8_t x, uint8_t y);
+    void draw_mah(uint8_t x, uint8_t y, bool available, bool blink, float mah, bool can_be_negative);
     void draw_sats(uint8_t x, uint8_t y);
     void draw_fltmode(uint8_t x, uint8_t y);
     void draw_message(uint8_t x, uint8_t y);
@@ -296,9 +305,11 @@ private:
     void draw_flightime(uint8_t x, uint8_t y);
     void draw_climbeff(uint8_t x, uint8_t y);
     void draw_eff(uint8_t x, uint8_t y);
+    void draw_avg_eff(uint8_t x, uint8_t y);
     void draw_atemp(uint8_t x, uint8_t y);
     void draw_bat2_vlt(uint8_t x, uint8_t y);
     void draw_bat2used(uint8_t x, uint8_t y);
+    void draw_bat2rem(uint8_t x, uint8_t y);
     void draw_clk(uint8_t x, uint8_t y);
     void draw_callsign(uint8_t x, uint8_t y);
     void draw_current2(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -637,7 +637,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 
     // @Param: EFF_EN
     // @DisplayName: EFF_EN
-    // @Description: Displays flight efficiency (mAh/km or /mi)
+    // @Description: Displays flight efficiency (mAh or Wh / km or mi)
     // @Values: 0:Disabled,1:Enabled
 
     // @Param: EFF_X
@@ -1073,21 +1073,21 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     
     //Custom Entries: (IDs start from 63 and go down to avoid conflicts with upstream)
 
-    // @Param: ENERGY_EN
-    // @DisplayName: ENERGY_EN
+    // @Param: NRG_CONS_EN
+    // @DisplayName: NRG_CONS_EN
     // @Description: Displays total energy consumed from primary battery
     // @Values: 0:Disabled,1:Enabled
 
-    // @Param: ENERGY_X
-    // @DisplayName: ENERGY_X
+    // @Param: NRG_CONS_X
+    // @DisplayName: NRG_CONS_X
     // @Description: Horizontal position on screen
     // @Range: 0 29
 
-    // @Param: ENERGY_Y
-    // @DisplayName: ENERGY_Y
+    // @Param: NRG_CONS_Y
+    // @DisplayName: NRG_CONS_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
-    AP_SUBGROUPINFO(energy, "ENERGY", 63, AP_OSD_Screen, AP_OSD_Setting),
+    AP_SUBGROUPINFO(energy_consumed, "NRG_CONS", 63, AP_OSD_Screen, AP_OSD_Setting),
 
     // @Param: RC_THR_EN
     // @DisplayName: RC_THR_EN
@@ -1296,6 +1296,70 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(resting_avgcellvolt, "R_AVG_CV", 50, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: NRG_REM_EN
+    // @DisplayName: NRG_REM_EN
+    // @Description: Displays energy remaining in primary battery
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: NRG_REM_X
+    // @DisplayName: NRG_REM_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: NRG_REM_Y
+    // @DisplayName: NRG_REM_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(energy_remaining, "NRG_REM", 49, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: AVG_EFF_EN
+    // @DisplayName: AVG_EFF_EN
+    // @Description: Displays average flight efficiency (mAh or Wh / km or mi)
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: AVG_EFF_X
+    // @DisplayName: AVG_EFF_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: AVG_EFF_Y
+    // @DisplayName: AVG_EFF_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(avg_eff, "AVG_EFF", 48, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: BATREM_EN
+    // @DisplayName: BATREM_EN
+    // @Description: Displays primary battery mAh remaining
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: BATREM_X
+    // @DisplayName: BATREM_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: BATREM_Y
+    // @DisplayName: BATREM_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(batrem, "BATREM", 47, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: BAT2REM_EN
+    // @DisplayName: BAT2REM_EN
+    // @Description: Displays secondary battery mAh consumed
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: BAT2REM_X
+    // @DisplayName: BAT2REM_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: BAT2REM_Y
+    // @DisplayName: BAT2REM_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(bat2rem, "BAT2REM", 46, AP_OSD_Screen, AP_OSD_Setting),
 
     AP_GROUPEND
 };
@@ -1555,22 +1619,25 @@ void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)
     backend->write(x, y, false, "%4d%c", (int)u_scale(ALTITUDE, alt), u_icon(ALTITUDE));
 }
 
-void AP_OSD_Screen::draw_cellvolt(uint8_t x, uint8_t y, const float cell_voltage, const bool blink)
+void AP_OSD_Screen::draw_cellvolt(uint8_t x, uint8_t y, const float cell_voltage, const bool volt_blink)
 {
     AP_BattMonitor &battery = AP::battery();
     uint8_t pct;
     bool pct_available = battery.capacity_remaining_pct(pct);
-    uint8_t pct_symbol;
+    uint8_t batt_symbol;
     if (pct_available) {
         uint8_t p = (100 - pct) / 16.6;
-        pct_symbol = SYMBOL(SYM_BATT_FULL) + p;
+        batt_symbol = SYMBOL(SYM_BATT_FULL) + p;
     }
     if (pct_available) {
-        backend->write(x, y, blink, "%c%1.2f%c", pct_symbol, cell_voltage, SYMBOL(SYM_VOLT));
+        const bool batt_blink = battery.remaining_mah_is_low() || battery.remaining_wh_is_low();
+        backend->write(x, y, batt_blink, "%c", batt_symbol);
+        backend->write(x+1, y, volt_blink, "%1.2f%c", cell_voltage, SYMBOL(SYM_VOLT));
     } else if (battery.capacity_has_been_configured()) {
-        backend->write(x, y, blink, "%c%1.2f%c", SYMBOL(SYM_BATT_UNKNOWN), cell_voltage, SYMBOL(SYM_VOLT));
+        backend->write(x, y, false, "%c", SYMBOL(SYM_BATT_UNKNOWN));
+        backend->write(x+1, y, volt_blink, "%1.2f%c", cell_voltage, SYMBOL(SYM_VOLT));
     } else {
-        backend->write(x + 1, y, blink, "%1.2f%c", cell_voltage, SYMBOL(SYM_VOLT));
+        backend->write(x + 1, y, volt_blink, "%1.2f%c", cell_voltage, SYMBOL(SYM_VOLT));
     }
 }
 
@@ -1578,16 +1645,16 @@ void AP_OSD_Screen::draw_avgcellvolt(uint8_t x, uint8_t y)
 {
     AP_BattMonitor &battery = AP::battery();
     const float cell_voltage = battery.cell_avg_voltage();
-    const bool blink = battery.voltage_is_low();
-    draw_cellvolt(x, y, cell_voltage, blink);
+    const bool volt_blink = battery.voltage_is_low();
+    draw_cellvolt(x, y, cell_voltage, volt_blink);
 }
 
 void AP_OSD_Screen::draw_resting_avgcellvolt(uint8_t x, uint8_t y)
 {
     AP_BattMonitor &battery = AP::battery();
     const float cell_voltage = battery.resting_cell_avg_voltage();
-    const bool blink = battery.resting_voltage_is_low();
-    draw_cellvolt(x, y, cell_voltage, blink);
+    const bool volt_blink = battery.resting_voltage_is_low();
+    draw_cellvolt(x, y, cell_voltage, volt_blink);
 }
 
 void AP_OSD_Screen::draw_restvolt(uint8_t x, uint8_t y)
@@ -1609,46 +1676,38 @@ void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
     AP_BattMonitor &battery = AP::battery();
     float v = battery.voltage();
     uint8_t pct;
-    const bool blink = battery.voltage_is_low();
+    const bool volt_blink = battery.voltage_is_low();
     if (!battery.capacity_remaining_pct(pct)) {
         if (battery.capacity_has_been_configured()) {
-            backend->write(x,y, blink, "%c%2.1f%c", SYMBOL(SYM_BATT_UNKNOWN), (double)v, SYMBOL(SYM_VOLT));
+            backend->write(x, y, false, "%c", SYMBOL(SYM_BATT_UNKNOWN));
+            backend->write(x+1, y, volt_blink, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
         } else {
             // Do not show battery percentage
-            backend->write(x+1,y, blink, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
+            backend->write(x+1, y, volt_blink, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
         }
         return;
     }
+    const bool batt_blink = battery.remaining_mah_is_low() || battery.remaining_wh_is_low();
     uint8_t p = (100 - pct) / 16.6;
-    backend->write(x,y, blink, "%c%2.1f%c", SYMBOL(SYM_BATT_FULL) + p, (double)v, SYMBOL(SYM_VOLT));
+    backend->write(x, y, batt_blink, "%c", SYMBOL(SYM_BATT_FULL) + p);
+    backend->write(x+1, y, volt_blink, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
 }
 
 void AP_OSD_Screen::draw_bat_pct(uint8_t x, uint8_t y)
 {
     AP_BattMonitor &battery = AP::battery();
 
-    float consumed_mah;
-    float consumed_wh;
-    bool has_consumed_mah = false;
-    bool has_consumed_wh = false;
-    if (battery.consumed_mah(consumed_mah)) {
-        has_consumed_mah = true;
-    }
-    if (battery.consumed_wh(consumed_wh)) {
-        has_consumed_wh = true;
-    }
-
-    const bool blink = battery.voltage_is_low() ||
-                       (is_positive(battery.low_capacity_mah()) && (!has_consumed_mah || ((battery.pack_capacity_mah() - consumed_mah) < battery.low_capacity_mah()))) ||
-                       (is_positive(battery.low_capacity_wh()) && (!has_consumed_wh || ((battery.pack_capacity_wh() - consumed_wh) < battery.low_capacity_wh())));
+    const bool blink = battery.voltage_is_low() || battery.remaining_mah_is_low() || battery.remaining_wh_is_low();
 
     uint8_t pct;
+
     if (!battery.capacity_remaining_pct(pct)) {
         if (!AP_Notify::flags.armed) {
             backend->write(x , y , false , "---%c" , SYMBOL(SYM_PCNT));
         }
         return;
     }
+
     backend->write(x, y, blink, "%3d%c", (uint16_t)lrintf(pct), SYMBOL(SYM_PCNT));
 }
 
@@ -1721,18 +1780,33 @@ void AP_OSD_Screen::draw_power(uint8_t x, uint8_t y)
     }
 }
 
-void AP_OSD_Screen::draw_energy(uint8_t x, uint8_t y)
+void AP_OSD_Screen::draw_energy(uint8_t x, uint8_t y, bool available, bool blink, float energy_wh, bool can_be_negative)
+{
+    if (!available) {
+        const char *fmt = can_be_negative ? "-----%c" : "----%c";
+        backend->write(x, y, false, fmt, SYMBOL(SYM_WH));
+        return;
+    }
+    // const uint8_t spaces = can_be_negative ? (signbit(energy_wh) ? 0 : 1) : 0;
+    const uint8_t spaces = !can_be_negative || signbit(energy_wh) ? 0 : 1;
+    const char* const fmt = (energy_wh < 9.9995 ? "%1.3f%c" : (energy_wh < 99.995 ? "%2.2f%c" : "%3.1f%c"));
+    backend->write(x + spaces, y, blink, fmt, energy_wh, SYMBOL(SYM_WH));
+}
+
+void AP_OSD_Screen::draw_energy_consumed(uint8_t x, uint8_t y)
 {
     AP_BattMonitor &battery = AP::battery();
     float energy_wh;
-    if (!battery.consumed_wh(energy_wh)) {
-        // consumed energy unavailable
-        backend->write(x, y, false, "----%c", SYMBOL(SYM_WH));
-        return;
-    }
-    const char* const fmt = (energy_wh < 9.9995 ? "%1.3f%c" : (energy_wh < 99.995 ? "%2.2f%c" : "%3.1f%c"));
-    const bool blink = is_positive(battery.low_capacity_wh()) && (battery.pack_capacity_wh() - energy_wh) < battery.low_capacity_wh();
-    backend->write(x, y, blink, fmt, energy_wh, SYMBOL(SYM_WH));
+    const bool available = battery.consumed_wh(energy_wh);
+    draw_energy(x, y, available, battery.remaining_wh_is_low(), energy_wh, false);
+}
+
+void AP_OSD_Screen::draw_energy_remaining(uint8_t x, uint8_t y)
+{
+    AP_BattMonitor &battery = AP::battery();
+    float energy_wh;
+    const bool available = battery.remaining_wh(energy_wh);
+    draw_energy(x, y, available, battery.remaining_wh_is_low(), energy_wh, true);
 }
 
 void AP_OSD_Screen::draw_fltmode(uint8_t x, uint8_t y)
@@ -1758,25 +1832,43 @@ void AP_OSD_Screen::draw_sats(uint8_t x, uint8_t y)
     backend->write(x, y, flash, "%c%c%2u", SYMBOL(SYM_SAT_L), SYMBOL(SYM_SAT_R), nsat);
 }
 
-void AP_OSD_Screen::draw_batused(uint8_t instance, uint8_t x, uint8_t y)
+void AP_OSD_Screen::draw_mah(uint8_t x, uint8_t y, bool available, bool blink, float mah, bool can_be_negative)
+{
+    const uint8_t spaces = !can_be_negative || signbit(mah) ? 0 : 1;
+    if (mah < 9999.5) {
+        backend->write(x+spaces, y, blink, "%.0f%c", mah, SYMBOL(SYM_MAH));
+    } else {
+        const float ah = mah * 1e-3f;
+        backend->write(x+spaces, y, blink, "%2.2f%c", ah, SYMBOL(SYM_AH));
+    }
+}
+
+void AP_OSD_Screen::draw_batused(uint8_t x, uint8_t y, uint8_t instance)
 {
     float mah;
     AP_BattMonitor &battery = AP::battery();
-    if (!battery.consumed_mah(mah, instance)) {
-        mah = 0;
-    }
-    const bool blink = is_positive(battery.low_capacity_mah()) && (battery.pack_capacity_mah() - mah) < battery.low_capacity_mah();
-    if (mah <= 9999) {
-        backend->write(x,y, blink, "%4d%c", (int)mah, SYMBOL(SYM_MAH));
-    } else {
-        const float ah = mah * 1e-3f;
-        backend->write(x,y, blink, "%2.2f%c", (double)ah, SYMBOL(SYM_AH));
-    }
+    const bool consumed_mah_available = battery.consumed_mah(mah, instance);
+    const bool blink = battery.remaining_mah_is_low();
+    draw_mah(x, y, consumed_mah_available, blink, mah, false);
 }
 
 void AP_OSD_Screen::draw_batused(uint8_t x, uint8_t y)
 {
-    draw_batused(0, x, y);
+    draw_batused(x, y, 0);
+}
+
+void AP_OSD_Screen::draw_batrem(uint8_t x, uint8_t y, uint8_t instance)
+{
+    float mah;
+    AP_BattMonitor &battery = AP::battery();
+    const bool mah_available = battery.remaining_mah(mah, instance);
+    const bool blink = battery.remaining_mah_is_low();
+    draw_mah(x, y, mah_available, blink, mah, true);
+}
+
+void AP_OSD_Screen::draw_batrem(uint8_t x, uint8_t y)
+{
+    draw_batrem(x, y, 0);
 }
 
 //Autoscroll message is the same as in minimosd-extra.
@@ -2524,13 +2616,40 @@ void AP_OSD_Screen::draw_eff(uint8_t x, uint8_t y)
         backend->write(x, y, false, "%c%3d%c", SYMBOL(SYM_EFF), efficiency, SYMBOL(SYM_MAH));
     } else {
         float power_w;
-        if (!battery.power_watts(power_w) || is_negative(power_w)) goto invalid;
+        if (!battery.power_watts_without_losses(power_w) || is_negative(power_w)) goto invalid;
         const float efficiency = power_w / speed;
-        if (roundf(efficiency) > 999) goto invalid;
+        if (!isfinite(efficiency) || roundf(efficiency) > 999) goto invalid;
         const char* const fmt = (efficiency < 9.995 ? "%c%1.2f%c" : (efficiency < 99.95 ? "%c%2.1f%c" : "%c%3.0f%c"));
         backend->write(x, y, false, fmt, SYMBOL(SYM_EFF), efficiency, SYMBOL(SYM_WH));
     }
     return;
+invalid:
+    const uint8_t unit_symbol = SYMBOL(eff_unit_base == AP_OSD::EFF_UNIT_BASE_MAH ? SYM_MAH : SYM_WH);
+    backend->write(x, y, false, "%c---%c", SYMBOL(SYM_EFF), unit_symbol);
+}
+
+void AP_OSD_Screen::draw_avg_eff(uint8_t x, uint8_t y)
+{
+    int8_t eff_unit_base = osd->efficiency_unit_base;
+    const float distance_traveled_km = osd->_stats.last_distance_m * 0.001f;
+    if (is_positive(distance_traveled_km)) {
+        AP_BattMonitor& battery = AP::battery();
+        if (eff_unit_base == AP_OSD::EFF_UNIT_BASE_MAH) {
+            float consumed_mah;
+            if (!battery.consumed_mah(consumed_mah)) goto invalid;
+            const uint16_t efficiency = roundf(consumed_mah / distance_traveled_km);
+            if (efficiency > 999) goto invalid;
+            backend->write(x, y, false, "%c%3d%c", SYMBOL(SYM_EFF), efficiency, SYMBOL(SYM_MAH));
+        } else {
+            float consumed_wh;
+            if (!battery.consumed_wh_without_losses(consumed_wh)) goto invalid;
+            const float efficiency = consumed_wh / distance_traveled_km;
+            if (!isfinite(efficiency) || roundf(efficiency) > 999) goto invalid;
+            const char* const fmt = (efficiency < 9.995 ? "%c%1.2f%c" : (efficiency < 99.95 ? "%c%2.1f%c" : "%c%3.0f%c"));
+            backend->write(x, y, false, fmt, SYMBOL(SYM_EFF), efficiency, SYMBOL(SYM_WH));
+        }
+        return;
+    }
 invalid:
     const uint8_t unit_symbol = SYMBOL(eff_unit_base == AP_OSD::EFF_UNIT_BASE_MAH ? SYM_MAH : SYM_WH);
     backend->write(x, y, false, "%c---%c", SYMBOL(SYM_EFF), unit_symbol);
@@ -2618,7 +2737,12 @@ void AP_OSD_Screen::draw_bat2_vlt(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_bat2used(uint8_t x, uint8_t y)
 {
-    draw_batused(1, x, y);
+    draw_batused(x, y, 1);
+}
+
+void AP_OSD_Screen::draw_bat2rem(uint8_t x, uint8_t y)
+{
+    draw_batrem(x, y, 1);
 }
 
 void AP_OSD_Screen::draw_aspd1(uint8_t x, uint8_t y)
@@ -2831,9 +2955,12 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(link_quality);
     DRAW_SETTING(current);
     DRAW_SETTING(power);
-    DRAW_SETTING(energy);
+    DRAW_SETTING(energy_consumed);
+    DRAW_SETTING(energy_remaining);
     DRAW_SETTING(batused);
+    DRAW_SETTING(batrem);
     DRAW_SETTING(bat2used);
+    DRAW_SETTING(bat2rem);
     DRAW_SETTING(sats);
     DRAW_SETTING(fltmode);
     DRAW_SETTING(gspeed);
@@ -2879,6 +3006,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(stat);
     DRAW_SETTING(climbeff);
     DRAW_SETTING(eff);
+    DRAW_SETTING(avg_eff);
     DRAW_SETTING(callsign);
     DRAW_SETTING(current2);
     DRAW_SETTING(rc_throttle);


### PR DESCRIPTION
- Add average efficiency
- Use energy consumed without power losses for efficiency calculations
- Power now includes losses
- Possibility to display remaining Wh and Ah
- The OSD voltage elements will now blink the battery symbol (low capacity) separately from the voltage (low voltage)
- Some code fixes and improvement