### PR TITLE
Plane: enable throttle battery compensation in manual mode

### DIFF
--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -50,6 +50,10 @@ public:
         return get_singleton() != nullptr && (_options & uint32_t(Option::PLANE_DISABLE_MAN_THR_EXPO));
     }
 
+    bool throttle_battery_compensation_is_disabled_in_manual_mode(void) const {
+        return get_singleton() != nullptr && (_options & uint32_t(Option::PLANE_DISABLE_MAN_BAT_COMP));
+    }
+
     RC_Channel *get_arming_channel(void) const override;
 
 protected:

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -417,6 +417,13 @@ void Plane::set_servos_manual_passthrough(void)
 
     apply_throttle_dz();
 
+    if (!g2.rc_channels.throttle_battery_compensation_is_disabled_in_manual_mode()) {
+        // conpensate for battery voltage drop
+        int8_t min_throttle = -100;
+        int8_t max_throttle = 100;
+        throttle_voltage_comp(min_throttle, max_throttle);
+    }
+
     if (!g2.rc_channels.throttle_expo_is_disabled_in_manual_mode()) {
         apply_throttle_expo();
     }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -578,6 +578,7 @@ protected:
         SUPPRESS_CRSF_MESSAGE   = (1U << 9), // suppress CRSF mode/rate message for ELRS systems
         MULTI_RECEIVER_SUPPORT  = (1U << 10), // allow multiple receivers
         USE_CRSF_LQ_AS_RSSI     = (1U << 11), // returns CRSF link quality as RSSI value, instead of RSSI
+        PLANE_DISABLE_MAN_BAT_COMP  = (1U << 22), // plane only: disable throttle battery voltage compensation in manual mode
         PLANE_DISABLE_MAN_THR_EXPO  = (1U << 23), // plane only: disable throttle expo in manual mode
     };
 

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:CRSF RSSI shows Link Quality, 23:Disable throttle expo in manual mode (plane only)
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:CRSF RSSI shows Link Quality, 22:Disable throttle battery compensation in manual mode (plane only), 23:Disable throttle expo in manual mode (plane only)
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE | (uint32_t)RC_Channels::Option::SUPPRESS_CRSF_MESSAGE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
It is possible to disable it with bit 22 in `RC_OPTIONS`