### PR TITLE
Plane: enable loiter alt control even with stick mixing disabled

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -133,7 +133,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: When enabled, this adds user stick input to the control surfaces in auto modes, allowing the user to have some degree of flight control without changing modes.  There are two types of stick mixing available. If you set STICK_MIXING to 1 then it will use "fly by wire" mixing, which controls the roll and pitch in the same way that the FBWA mode does. This is the safest option if you usually fly ArduPlane in FBWA or FBWB mode. If you set STICK_MIXING to 2 then it will enable direct mixing mode, which is what the STABILIZE mode uses. That will allow for much more extreme maneuvers while in AUTO mode. If you set STICK_MIXING to 3 then it will apply to the yaw while in quadplane modes only, such as while doing an automatic VTOL takeoff or landing.
     // @Values: 0:Disabled,1:FBWMixing,2:DirectMixing,3:VTOL Yaw only
     // @User: Advanced
-    GSCALAR(stick_mixing,           "STICK_MIXING",   uint8_t(StickMixing::FBW)),
+    GSCALAR(stick_mixing,           "STICK_MIXING",   uint8_t(StickMixing::NONE)),
 
     // @Param: TKOFF_THR_MINSPD
     // @DisplayName: Takeoff throttle min speed

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -18,9 +18,9 @@ bool ModeLoiter::_enter()
 void ModeLoiter::update()
 {
     plane.calc_nav_roll();
-    if (plane.stick_mixing_enabled() && ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0)) {
+    if ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0) {
         plane.update_fbwb_speed_height();
-    } else {
+    } else if (plane.stick_mixing_enabled()) {
         plane.calc_nav_pitch();
         plane.calc_throttle();
     }

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2120,6 +2120,7 @@ function'''
 
     def LOITER(self):
         # first test old loiter behavour
+        self.set_parameter("STICK_MIXING", 1)
         self.set_parameter("FLIGHT_OPTIONS", 1 << 23)
         self.takeoff(alt=200)
         self.set_rc(3, 1500)


### PR DESCRIPTION
...and disable stick mixing by default