### PR TITLE
Plane: fix throttle output unsynchronized concurrent access

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -210,6 +210,9 @@ private:
     AP_YawController yawController{aparm};
     AP_SteerController steerController{};
 
+    HAL_Semaphore _thr_sem;
+    float _throttle_output;
+
     // Training mode
     bool training_manual_roll;  // user has manual roll control
     bool training_manual_pitch; // user has manual pitch control

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -1010,6 +1010,11 @@ void Plane::set_servos(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, override_pct);
     }
 
+    {
+        WITH_SEMAPHORE(_thr_sem);
+        _throttle_output = SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::k_throttle);
+    }
+
     // run output mixer and send values to the hal for output
     servos_output();
 }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -439,11 +439,8 @@ float Plane::throttle_percentage(void)
         return quadplane.motors->get_throttle_out() * 100.0;
     }
 #endif
-    float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
-    if (!have_reverse_thrust()) {
-        return constrain_float(throttle, 0, 100);
-    }
-    return constrain_float(throttle, -100, 100);
+    WITH_SEMAPHORE(_thr_sem);
+    return _throttle_output;
 }
 
 // update the harmonic notch filter center frequency dynamically


### PR DESCRIPTION
Was causing the output throttle displayed on the OSD and the GCS to sometimes not show the right value