### PR TITLE
Plane: use target airspeed for auto flaps when throttle is suppressed

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -804,7 +804,7 @@ void Plane::set_servos_flaps(void)
     if (control_mode->does_auto_throttle()) {
         float flapSpeedSource = 0;
         if (ahrs.airspeed_sensor_enabled()) {
-            flapSpeedSource = TECS_controller.get_target_airspeed();
+            flapSpeedSource = throttle_suppressed ? target_airspeed_cm * 0.01f : TECS_controller.get_target_airspeed();
         } else {
             flapSpeedSource = aparm.throttle_cruise;
         }


### PR DESCRIPTION
Use target airspeed from user input instead of TECS target airspeed when the throttle is suppressed making it possible to test auto flaps on the ground