### PR TITLE
Un-cap RF_Mode for CRSF protocol

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -511,7 +511,7 @@ void AP_RCProtocol_CRSF::process_link_stats_frame(const void* data)
         }
     }
 
-    _link_status.rf_mode = MIN(link->rf_mode, 7U);
+    _link_status.rf_mode = link->rf_mode;
     _link_status.tx_power = link->uplink_tx_power < sizeof(AP_RCProtocol_CRSF::tx_powers) ? AP_RCProtocol_CRSF::tx_powers[link->uplink_tx_power] : -1;
     _link_status.snr = link->uplink_snr;
     _link_status.active_antenna = link->active_antenna;


### PR DESCRIPTION
The `RF_Mode` byte in the CRSF protocol is used to communicate the current RF parameters between the RX and the FC.
The value is an enum, where each value represents a different mode of operation, e.g in ELRS mode 7 is 500Hz LoRa.
![photo_2022-05-05_09-39-03](https://user-images.githubusercontent.com/59873510/167399214-9320ce52-4093-4fec-96d0-942bd7cf41a6.jpg)


For some unknown reason, the `RF_Mode` was being capped to a max of 7 in the code. This creates problems when using the `master` branch on ELRS (soon to become v3.0), which uses modes >7. Removing the cap to allow showing these modes.