### PR TITLE
Copter: disarm safety

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -783,10 +783,8 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
         return true;
     }
 
-    // do not allow disarm via mavlink if we think we are flying:
-    if (do_disarm_checks &&
-        method == AP_Arming::Method::MAVLINK &&
-        !copter.ap.land_complete) {
+    // do not allow disarm if we think we are flying:
+    if (do_disarm_checks && !is_zero(copter.channel_throttle->get_control_in()) && !copter.ap.land_complete) {
         return false;
     }
 


### PR DESCRIPTION
Copter will not disarm while in flight unless the throttle is set to 0 prior to the disarm request