### PR TITLE
Plane: throttle cut emergency landing

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -290,6 +290,7 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
             plane.set_mode(*throttle_cut_prev_mode, ModeReason::RC_COMMAND);
         }
         set_throttle_cut(false);
+        plane.emergency_landing = emergency_landing_prev_status;
         gcs().send_text(MAV_SEVERITY_INFO , "Rearmed");
         return true;
     }
@@ -329,6 +330,8 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
         if (plane.is_flying()) {
             if (method == AP_Arming::Method::AUXSWITCH) {
                 set_throttle_cut(true);
+                emergency_landing_prev_status = plane.emergency_landing;
+                plane.emergency_landing = true;
                 if (plane.control_mode->does_auto_throttle()) {
                     throttle_cut_prev_mode = plane.control_mode;
                     plane.set_mode(plane.mode_fbwa, ModeReason::RC_COMMAND);

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -50,6 +50,8 @@ private:
     // mode the plane was in when throttle cut was enabled
     Mode *throttle_cut_prev_mode;
 
+    bool emergency_landing_prev_status;
+
     // oneshot with duration AP_ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;


### PR DESCRIPTION
Disarming with the arming channel during flight doesn't disarm the plane but just cuts throttle and allows rearming without doing the arming checks since V10.0. Now this change also enables emergency landing (forcing FBWA during FS) when throttle cut is enabled allowing to land away from home if the plane can't make it without triggering RTL when losing radio signal because of the proximity to the ground.

Closes #215 