### PR TITLE
Plane: throttle cut improvement for quadplane/tailsitter

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -325,20 +325,22 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
 {
     if (do_disarm_checks) {
 
-        // don't allow disarming in flight, cut the throttle instead and change mode to FBWA if in auto throttle mode
+        // FW: don't allow disarming in flight, cut the throttle instead and change mode to FBWA if in auto throttle mode
+        // VTOL mode: only stop the motors if the throttle is at 0
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (plane.is_flying()) {
             if (method == AP_Arming::Method::AUXSWITCH) {
                 set_throttle_cut(true);
                 emergency_landing_prev_status = plane.emergency_landing;
                 plane.emergency_landing = true;
-                if (plane.control_mode->does_auto_throttle()) {
+                if (!plane.control_mode->is_vtol_mode() && plane.control_mode->does_auto_throttle()) {
                     throttle_cut_prev_mode = plane.control_mode;
                     plane.set_mode(plane.mode_fbwa, ModeReason::RC_COMMAND);
                 } else {
                     throttle_cut_prev_mode = NULL;
                 }
-                gcs().send_text(MAV_SEVERITY_INFO , "Throttle cut by arm switch");
+                const bool disarm_prevented = !is_zero(plane.channel_throttle->get_control_in()) && plane.control_mode->is_vtol_mode();
+                gcs().send_text(MAV_SEVERITY_INFO , disarm_prevented ? "Disarm prevented" : "Throttle cut by arm switch");
             }
             // obviously this could happen in-flight so we can't warn about it
             return false;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1724,8 +1724,10 @@ void QuadPlane::update(void)
         return;
     }
 
+    const bool throttle_emergency_stop = plane.arming.get_throttle_cut() && is_zero(plane.channel_throttle->get_control_in());
+
     // keep motors interlock state upto date with E-stop
-    motors->set_interlock(!SRV_Channels::get_emergency_stop());
+    motors->set_interlock(!SRV_Channels::get_emergency_stop() && !throttle_emergency_stop);
 
     if ((ahrs_view != NULL) && !is_equal(_last_ahrs_trim_pitch, ahrs_trim_pitch.get())) {
         _last_ahrs_trim_pitch = ahrs_trim_pitch.get();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -1197,6 +1197,12 @@ void Plane::servos_output(void)
     quadplane.tiltrotor.bicopter_output();
 #endif
 
+    if (arming.get_throttle_cut()) {
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle , 0.0);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft , 0.0);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight , 0.0);
+    }
+
     // support forced flare option
     force_flare();
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2396,7 +2396,8 @@ void AP_OSD_Screen::draw_throttle_value(uint8_t x, uint8_t y, float throttle_v, 
 
 void AP_OSD_Screen::draw_throttle_output(uint8_t x, uint8_t y)
 {
-    draw_throttle_value(x, y, gcs().get_hud_throttle(), AP_Notify::flags.throttle_cut || AP::vehicle()->is_auto_throttle_gliding());
+    const float throttle_value = gcs().get_hud_throttle();
+    draw_throttle_value(x, y, throttle_value, is_zero(throttle_value) && (AP_Notify::flags.throttle_cut || AP::vehicle()->is_auto_throttle_gliding()));
 }
 
 #if HAL_OSD_SIDEBAR_ENABLE


### PR DESCRIPTION
While flying stop motors in Q modes if arming switch put in disarmed position and throttle at 0. Previously the motors would only be stopped in forward flight modes while flying and arming switch put in disarmed position.